### PR TITLE
Upgrade PHP specs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ twilio==6.1.2
 inflection==0.3.1
 yapf==0.16.2
 jsbeautifier==1.6.14
+lxml==4.2.3
+inflection=0.3.1

--- a/twiml_generator/languages_specs/php.json
+++ b/twiml_generator/languages_specs/php.json
@@ -2,8 +2,8 @@
   "language": "php",
   "extension": ".php",
 
-  "voice_class": "Twiml",
-  "messaging_class": "Twiml",
+  "voice_class": "TwiML",
+  "messaging_class": "TwiML",
 
   "text_format": "{text}, ",
   "attribute_format": "'{name}' => {value}",
@@ -14,8 +14,8 @@
   "code_wrapper_padding": 0,
 
   "add_imports": "fixed",
-  "import_voice": "<?php\nrequire_once './vendor/autoload.php';\nuse Twilio\\Twiml;",
-  "import_messaging": "<?php\nrequire_once './vendor/autoload.php';\nuse Twilio\\Twiml;",
+  "import_voice": "<?php\nrequire_once './vendor/autoload.php';\nuse Twilio\\TwiML;",
+  "import_messaging": "<?php\nrequire_once './vendor/autoload.php';\nuse Twilio\\TwiML;",
   "new_variable": "${variable} = new {klass}({attributes});",
   "new_block": "${variable} = ${parent}->{variable}({text}{attributes});",
   "new_leaf": "${parent}->{method}({text}{attributes});",


### PR DESCRIPTION
Update PHP TwiML snippets to use class `TwiML` not `Twiml`.

Some PHP TwiML code snippets are using the old `Twiml` class instead of the new `TwiML` (Yoyodyne-powered) class. DX team will be deprecating `Twiml` in the future, so need to get these snippets updated to use the new syntax.