### PR TITLE
Add missing Java specificities and allow for specifying generated code output file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ ENV/
 
 # VSCode settings
 .vscode
+
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -17,10 +17,21 @@ A tool to help generate sample code for creating TwiML with Twilio's helper libr
 
 ## Using the tool
 
-You can use `./generator.py` to print out code from a TwiML file
+You can use `./generator.py` to print out and save code that is generated from a TwiML file:
 
 ```bash
 $ ./generator.py assets/call_on_hold.xml -l python
+# optionally specify where the output file should be written. If not specified,
+# it will be written to a /generators/<language> directory
+$ ./generator.py assets/call_on_hold.xml -out assets/call_on_hold.py -l python
+```
+
+You can also skip the code generation and verify that an existing code sample correctly matches
+the TwiML definition.
+
+```bash
+# the first file is the TwiML example, and the second file is the code to verify
+$ ./generator.py assets/call_on_hold.xml -out assets/call_on_hold.py -l python --verify
 ```
 
 ## Using it as a Library

--- a/generator.py
+++ b/generator.py
@@ -9,10 +9,11 @@ if __name__ == '__main__':
     parser.add_argument("twiml_filepath", help="Path to a TwiML file")
     parser.add_argument("-l", "--language", help="Language for the code to generate",
                         choices=['csharp', 'java', 'node', 'php', 'python', 'ruby'])
+    parser.add_argument("-out", "--outpath",  help="[optional] Path to output file")
     parser.add_argument("--verify",  action='store_false', help="Only runs the verification")
     args = parser.parse_args()
 
-    code_generator = TwimlCodeGenerator(args.twiml_filepath, language=args.language)
+    code_generator = TwimlCodeGenerator(args.twiml_filepath, code_filepath=args.outpath, language=args.language)
     if args.verify:
         code_generator.write_code()
         print(' CODE GENERATED '.center(80, '='))

--- a/twiml_generator/specificity/java.py
+++ b/twiml_generator/specificity/java.py
@@ -81,6 +81,9 @@ class Dial:
         to_enum(verb, 'record')
         to_bytes(verb, 'record')
 
+        to_enum(verb, 'recordingTrack')
+        to_bytes(verb, 'recordingTrack')
+
         to_enum(verb, 'trim')
         to_bytes(verb, 'trim')
 
@@ -175,6 +178,9 @@ class Pay:
     def process(cls, verb, imports):
         to_enum(verb, 'language')
         to_bytes(verb, 'language')
+
+        to_enum(verb, 'tokenType')
+        to_bytes(verb, 'tokenType')
 
         to_list(verb, 'validCardTypes', imports,
                 transform=enum_builder(verb, 'validCardTypes'))


### PR DESCRIPTION
I grouped a few updates in this PR:

#### [Commit 34af19d](https://github.com/TwilioDevEd/twiml-generator/commit/34af19d5ffb3a42523e672bf1944039bc6d0887a) Adding missing Java specificities

Fixes errors when generating TwiML. Before:
```
================================ CODE GENERATED ================================
import com.twilio.twiml.voice.Dial;
import com.twilio.twiml.voice.Number;
import com.twilio.twiml.VoiceResponse;
import com.twilio.twiml.TwiMLException;


public class Example {
    public static void main(String[] args) {
        Number number = new Number.Builder("+15551239876").build();
        Dial dial = new Dial.Builder().record(Dial.Record.RECORD_FROM_ANSWER).recordingTrack("inbound").recordingStatusCallback("https://www.myexample.com/recording-handler").number(number).build();
        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();

        try {
            System.out.println(response.toXml());
        } catch (TwiMLException e) {
            e.printStackTrace();
        }
    }
}

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/voice/dial/dial-7/generators/java/dial-7.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/voice/dial/dial-7/generators/java/dial-7.twiml: [error]

Example.java:10: error: incompatible types: String cannot be converted to RecordingTrack
        Dial dial = new Dial.Builder().record(Dial.Record.RECORD_FROM_ANSWER).recordingTrack("inbound").recordingStatusCallback("https://www.myexample.com/recording-handler").number(number).build();



================================ CODE GENERATED ================================
import com.twilio.twiml.voice.Pay;
import com.twilio.twiml.VoiceResponse;
import com.twilio.twiml.TwiMLException;


public class Example {
    public static void main(String[] args) {
        Pay pay = new Pay.Builder().tokenType("one-time").chargeAmount("0").build();
        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

        try {
            System.out.println(response.toXml());
        } catch (TwiMLException e) {
            e.printStackTrace();
        }
    }
}

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/voice/pay/pay-tokenize/generators/java/pay-tokenize.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/voice/pay/pay-tokenize/generators/java/pay-tokenize.twiml: [error]

Example.java:8: error: incompatible types: String cannot be converted to TokenType
        Pay pay = new Pay.Builder().tokenType("one-time").chargeAmount("0").build();
```
After:
```
================================ CODE GENERATED ================================
import com.twilio.twiml.voice.Dial;
import com.twilio.twiml.voice.Number;
import com.twilio.twiml.VoiceResponse;
import com.twilio.twiml.TwiMLException;


public class Example {
    public static void main(String[] args) {
        Number number = new Number.Builder("+15551239876").build();
        Dial dial = new Dial.Builder().record(Dial.Record.RECORD_FROM_ANSWER).recordingTrack(Dial.RecordingTrack.INBOUND).recordingStatusCallback("https://www.myexample.com/recording-handler").number(number).build();
        VoiceResponse response = new VoiceResponse.Builder().dial(dial).build();

        try {
            System.out.println(response.toXml());
        } catch (TwiMLException e) {
            e.printStackTrace();
        }
    }
}

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/voice/dial/dial-7/generators/java/dial-7.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/voice/dial/dial-7/generators/java/dial-7.twiml: [passed]

================================ CODE GENERATED ================================
import com.twilio.twiml.voice.Pay;
import com.twilio.twiml.VoiceResponse;
import com.twilio.twiml.TwiMLException;


public class Example {
    public static void main(String[] args) {
        Pay pay = new Pay.Builder().tokenType(Pay.TokenType.ONE_TIME).chargeAmount("0").build();
        VoiceResponse response = new VoiceResponse.Builder().pay(pay).build();

        try {
            System.out.println(response.toXml());
        } catch (TwiMLException e) {
            e.printStackTrace();
        }
    }
}

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/voice/pay/pay-tokenize/generators/java/pay-tokenize.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/voice/pay/pay-tokenize/generators/java/pay-tokenize.twiml: [passed]
```

#### [Commit a2a3bd5](https://github.com/TwilioDevEd/twiml-generator/commit/a2a3bd5b15be9e908a537a0459daa4344955bfdc) Specifying output file when calling the generator command

Add an optional command-line argument for where to save the generated output file when running `generator.py`

#### [Commit d453a3d](https://github.com/TwilioDevEd/twiml-generator/commit/d453a3dd5ef909e7631bb3140dc54493692134d9) Documenting more usage examples

Gives a few more examples for how to use `generator.py` (like the --verify option)

Also added a trivial commit for updating the .gitignore with vim swp files