### PR TITLE
Add Messaging option to TwiML Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ For either option, you first need to create a TwiML file.
 
   :warning: When you add the Helper Library code files to the [api-snippets repo](https://github.com/TwilioDevEd/api-snippets/tree/master/twiml), the file extension must include the Helper Library version, e.g. `some-example.4.x.js`.  
 
+
+### Generate Messaging TwiML samples
+
+The vast majority of TwiML verbs are for Voice. If you would like to create a new TwiML code sample for Messaging rather than for Voice, you can pass in the `--messaging` flag:
+
+
+  `./generator.py <filepath of TwiML file> -out <filepath of code to verify> -l <Helper Library language> --messaging`
+
   
 ### Verify existing Helper Library code via the command line
 

--- a/generator.py
+++ b/generator.py
@@ -11,9 +11,10 @@ if __name__ == '__main__':
                         choices=['csharp', 'java', 'node', 'php', 'python', 'ruby'])
     parser.add_argument("-out", "--outpath",  help="[optional] Path to output file")
     parser.add_argument("--verify",  action='store_false', help="Only runs the verification")
+    parser.add_argument("--messaging", action='store_true',  help="Generate Messaging TwiML rather than Voice TwiML")
     args = parser.parse_args()
 
-    code_generator = TwimlCodeGenerator(args.twiml_filepath, code_filepath=args.outpath, language=args.language)
+    code_generator = TwimlCodeGenerator(args.twiml_filepath, code_filepath=args.outpath, language=args.language, is_messaging=args.messaging)
     if args.verify:
         code_generator.write_code()
         print(' CODE GENERATED '.center(80, '='))

--- a/twiml_generator/twiml_code_generator.py
+++ b/twiml_generator/twiml_code_generator.py
@@ -38,7 +38,7 @@ class TwimlCodeGenerator(object):
     """Class to generate the necessary code for outputing a given TwiML."""
     __specificities = Specificities()
 
-    def __init__(self, twiml_filepath, code_filepath=None, lib_filepath=None, language='python'):
+    def __init__(self, twiml_filepath, code_filepath=None, lib_filepath=None, language='python', is_messaging=False):
         self.language_spec = load_language_spec(language)
         self.twiml_filepath = Path(twiml_filepath)
         self.twimlir = TwimlIR(twiml_filepath)
@@ -48,6 +48,9 @@ class TwimlCodeGenerator(object):
             self.code_filepath = Path(code_filepath)
         else:
             self.code_filepath = code_filepath
+
+        if is_messaging:
+            self.twimlir.is_voice_response = False
 
         if lib_filepath:
             self.lib_filepath = Path(lib_filepath)


### PR DESCRIPTION
Based on this ticket: https://issues.corp.twilio.com/browse/DEVED-7129

The TwiML Generator currently only looks for one Messaging TwiML: the `<Message>` verb. https://github.com/TwilioDevEd/twiml-generator/blob/master/twiml_generator/twimlir.py#L89 If the verb is `<Message>`, then the TwiML Generator knows to generate code samples with MessagingResponses.

However, there is another Messaging TwiML, `<Redirect>`, which the generator should be able to generate MessagingResponse code samples for as well. There is also a Voice `<Redirect>` TwiML, so the generator can't distinguish whether the samples should be for messaging or voice just by the tag name.

This PR adds a new flag to the TwiML generator command, `--messaging`, which indicates that the output should include Messaging examples and not Voice examples.

Example of running the generator with the flag:
```
(venv) ❯ ./generator.py ../api-snippets/twiml/message/redirect/redirect-1/output/redirect-1.twiml -l python --messaging
================================ CODE GENERATED ================================
from twilio.twiml.messaging_response import Redirect, MessagingResponse

response = MessagingResponse()
response.redirect('http://www.foo.com/nextInstructions')

print(response)

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/message/redirect/redirect-1/generators/python/redirect-1.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/message/redirect/redirect-1/generators/python/redirect-1.twiml: [passed]
```

Example of running it without the flag:
```
(venv) ❯ ./generator.py ../api-snippets/twiml/message/redirect/redirect-1/output/redirect-1.twiml -l python
================================ CODE GENERATED ================================
from twilio.twiml.voice_response import Redirect, VoiceResponse

response = VoiceResponse()
response.redirect('http://www.foo.com/nextInstructions')

print(response)

================================================================================
Written at /Users/sstringer/src/api-snippets/twiml/message/redirect/redirect-1/generators/python/redirect-1.twiml
Running verification on /Users/sstringer/src/api-snippets/twiml/message/redirect/redirect-1/generators/python/redirect-1.twiml: [passed]
```